### PR TITLE
Fix profile link fallback and enrich profile page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <body>
     <div id="profile">
-        <a href="#" hx-get="/profile.html" hx-trigger="click" hx-target="#profile">Profile</a>
+        <a href="profile.html" hx-get="profile.html" hx-trigger="click" hx-target="#profile" hx-swap="outerHTML" hx-select="#profile">Profile</a>
     </div>
 </body>
 

--- a/profile.html
+++ b/profile.html
@@ -1,1 +1,17 @@
-<p>about me...</p>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile - Atish Mishra</title>
+</head>
+
+<body>
+    <div id="profile">
+        <p>about me...</p>
+    </div>
+</body>
+
+</html>
+


### PR DESCRIPTION
## Summary
- Ensure profile link works without JavaScript by providing real href
- Replace entire profile section with selected content when loaded via htmx
- Add full HTML structure to profile page for direct navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68969e5eca8c832cadd10ff33c065775