### PR TITLE
feat: add dark mode toggle and navigation styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <li><a href="#media">Music & Photos</a></li>
         <li><a href="#games">Games</a></li>
       </ul>
+      <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
     <section class="hero">
       <img id="avatar" src="https://via.placeholder.com/150" alt="Profile photo">

--- a/script.js
+++ b/script.js
@@ -18,5 +18,21 @@ fetch(`https://api.github.com/users/${githubUsername}`)
         bioElem.textContent = data.bio || '';
       }
     });
-  })
-  .catch(err => console.error('GitHub fetch failed', err));
+    })
+    .catch(err => console.error('GitHub fetch failed', err));
+
+const themeToggle = document.getElementById('theme-toggle');
+if (themeToggle) {
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    themeToggle.textContent = storedTheme === 'dark' ? '☀' : '🌙';
+  }
+  themeToggle.addEventListener('click', () => {
+    const currentTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', newTheme);
+    themeToggle.textContent = newTheme === 'dark' ? '☀' : '🌙';
+    localStorage.setItem('theme', newTheme);
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,9 +1,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
 
+html {
+  scroll-behavior: smooth;
+}
+
 :root {
   --bg: #fff;
   --text: #111;
   --accent: #e6002b;
+}
+
+[data-theme="dark"] {
+  --bg: #111;
+  --text: #f5f5f5;
 }
 
 * {
@@ -17,11 +26,11 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
+  transition: background 0.3s, color 0.3s;
 }
 
 nav {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
   background: var(--bg);
@@ -40,12 +49,33 @@ nav {
   list-style: none;
   display: flex;
   gap: 1.5rem;
+  margin-left: auto;
 }
 
 .nav-links a {
   text-decoration: none;
   color: var(--text);
   font-weight: 500;
+  transition: color 0.3s;
+}
+
+.nav-links a:hover {
+  color: var(--accent);
+}
+
+#theme-toggle {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-radius: 4px;
+  margin-left: 1rem;
+  font-weight: 600;
+}
+
+#theme-toggle:hover {
+  opacity: 0.9;
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- add a dark mode toggle that stores preference and updates theme variables
- refine navigation layout with hover styles and smooth scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a4715dc4832c8424617775f55b37